### PR TITLE
Update the `lang` attribute with the current lang. (#2995)

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -61,6 +61,7 @@ let currentLangData = {};
 export const setLanguage = async (lang: Language) => {
   currentLang = lang;
   document.documentElement.dir = currentLang.rtl ? "rtl" : "ltr";
+  document.documentElement.lang = currentLang.code;
 
   currentLangData = await import(
     /* webpackChunkName: "i18n-[request]" */ `./locales/${currentLang.code}.json`


### PR DESCRIPTION
Currently, when changing the app language, the `lang` attribute still in `en`.